### PR TITLE
Add markdown example, improve README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,18 @@ jobs:
     - <<: *examplephoto
       name: Example on Node 10
       node_js: '10'
+    - &examplemarkdown
+      name: Example on Node 8
+      stage: "[example] markdown integration"
+      node_js: '8'
+      before_install:
+        - cd examples/markdown-docs
+      install:
+        - yarn
+      before_script:
+        - cp -f ../../gatsby-node.js ./node_modules/gastby-source-airtable
+      script:
+        - yarn build
+    - <<: *examplemarkdown
+      name: Example on Node 10
+      node_js: '10'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-This is how we test# gatsby-source-airtable
-
 ## We are in process of combining namespaces. This codebase will be used for Gatsby v2 and forward.
 
 [![npm](https://img.shields.io/npm/v/gatsby-source-airtable/latest.svg?style=flat-square)](https://www.npmjs.com/package/gatsby-source-airtable)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm](https://img.shields.io/npm/v/gatsby-source-airtable/next.svg?style=flat-square)](https://www.npmjs.com/package/gatsby-source-airtable)
 [![Build Status](https://travis-ci.com/jbolda/gatsby-source-airtable.svg?branch=master)](https://travis-ci.com/jbolda/gatsby-source-airtable)
 
-Gatsby source plugin for pulling rows from multiple tables and bases in Airtable. This was inspired by [kevzettler/gatsby-source-airtable](https://github.com/kevzettler/gatsby-source-airtable), but due to the many breaking changes introduced, I started a new package (pretty much a complete rewrite). With the introduction of Gatsby v2, we felt it was a great time to combine the namespaces and this repository will be used moving forward. If you are looking for the documentation on `gatsby-source-airtable-linked`, see the additional branch. We do recommend moving your dependency over to this plugin, `gatsby-source-airtable`, for Gatsby v2. (If you are still on Gatsby v1, see `gatsby-source-airtable-linked` for compatibile code.)
+Gatsby source plugin for pulling rows from multiple tables and bases in Airtable. This was inspired by [kevzettler/gatsby-source-airtable](https://github.com/kevzettler/gatsby-source-airtable), but due to the many breaking changes introduced, I started a new package (pretty much a complete rewrite). With the introduction of Gatsby v2, we felt it was a great time to combine the namespaces and this repository will be used moving forward. If you are looking for the documentation on `gatsby-source-airtable-linked`, see the additional branch. We do recommend moving your dependency over to this plugin, `gatsby-source-airtable`, for Gatsby v2. (If you are still on Gatsby v1, see `gatsby-source-airtable-linked` for compatible code.)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Get all records from `YOUR_TABLE_NAME` where `Field_1 === YOUR_VALUE`
 
 ## How it works
 
-When running `gatsby develop` or `gatsby build`, this plugin will fetch all data for all rows in each of the tables you specify, making them available for query throughout your gatsby.js app, and to other gatsby plugins as well.
+When running `gatsby develop` or `gatsby build`, this plugin will fetch all data for all rows in each of the tables you specify, making them available for query throughout your gatsby.js app, and to other Gatsby plugins as well.
 
 As seen in the example above, `tables` is always specified as an array of table objects. These tables may be sourced from different bases.
 
@@ -101,7 +101,7 @@ This will create nested nodes accessible in your graphQL queries, as shown in th
 
 ### Using markdown and attachments
 
-Optionally, you may provide a "mapping". This will alert the plugin that column names you specify are of a specific, non-string format of your choosing. This is particularly useful if you would like to have gatsby pick up the fields for transforming, e.g. `text/markdown`. If you do not provide a mapping, Gatsby will just "infer" what type of value it is, which is most typically a `string`.
+Optionally, you may provide a "mapping". This will alert the plugin that column names you specify are of a specific, non-string format of your choosing. This is particularly useful if you would like to have Gatsby pick up the fields for transforming, e.g. `text/markdown`. If you do not provide a mapping, Gatsby will just "infer" what type of value it is, which is most typically a `string`.
 
 For an example of a markdown-and-airtable driven site using `gatsby-transformer-remark`, see the examples folder in this repo.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This will create nested nodes accessible in your graphQL queries, as shown in th
 
 Optionally, you may provide a "mapping". This will alert the plugin that column names you specify are of a specific, non-string format of your choosing. This is particularly useful if you would like to have Gatsby pick up the fields for transforming, e.g. `text/markdown`. If you do not provide a mapping, Gatsby will just "infer" what type of value it is, which is most typically a `string`.
 
-For an example of a markdown-and-airtable driven site using `gatsby-transformer-remark`, see the examples folder in this repo.
+For an example of a markdown-and-airtable-driven site using `gatsby-transformer-remark`, see the examples folder in this repo.
 
 If you are using the `Attachment` type field in Airtable, you may specify a column name with `fileNode` and the plugin will bring in these files. Using this method, it will create "nodes" for each of the files and expose this to all of the transformer plugins. A good use case for this would be attaching images in Airtable, and being able to make these available for use with the `sharp` plugins and `gatsby-image`. Specifying a `fileNode` does require a peer dependency of `gatsby-source-filesystem` otherwise it will fall back as a non-mapped field. The locally available files and any ecosystem connections will be available on the node as `localFiles`.
 
@@ -125,4 +125,4 @@ The API key can be specified in `gatsby-config.js` as noted in the previous sect
 
 Alternatively, you may specify your API key using an [Environment Variable](https://www.gatsbyjs.org/docs/environment-variables/). This plugin looks for an environment variable called `GATSBY_AIRTABLE_API_KEY` and will use it prior to resorting to the `apiKey` defined in `gatsby-config.js`. You may also specify it in your command line such as `GATSBY_AIRTABLE_API_KEY=XXXXXX gatsby develop`.
 
-If you add or your change your API key in an environment variable at the system level, you may need to reload your code editor / IDE for that variable to reload.
+If you add or change your API key in an environment variable at the system level, you may need to reload your code editor / IDE for that variable to reload.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# gatsby-source-airtable
+This is how we test# gatsby-source-airtable
+
 ## We are in process of combining namespaces. This codebase will be used for Gatsby v2 and forward.
 
 [![npm](https://img.shields.io/npm/v/gatsby-source-airtable/latest.svg?style=flat-square)](https://www.npmjs.com/package/gatsby-source-airtable)
 [![npm](https://img.shields.io/npm/v/gatsby-source-airtable/next.svg?style=flat-square)](https://www.npmjs.com/package/gatsby-source-airtable)
 [![Build Status](https://travis-ci.com/jbolda/gatsby-source-airtable.svg?branch=master)](https://travis-ci.com/jbolda/gatsby-source-airtable)
 
-Gatsby source plugin for pulling rows from an Airtable. This plugin will allow multiple tables and bases. Additionally, it will link the columns that you manually specify. This was inspired by [kevzettler/gatsby-source-airtable](https://github.com/kevzettler/gatsby-source-airtable), but due to the many breaking changes introduced, I started a new package (pretty much a complete rewrite). With the introduction of Gatsby v2, we felt it was a great time to combine the namespaces and this repository will be used moving forward. If you are looking for the documentation on `gatsby-source-airtable-linked`, see the additional branch. We do recommend moving your dependency over to `gatsby-source-airtable` for Gatsby v2. (If you are still on Gatsby v1, see `gatsby-source-airtable-linked` for compatibile code.)
+Gatsby source plugin for pulling rows from multiple tables and bases in Airtable. This was inspired by [kevzettler/gatsby-source-airtable](https://github.com/kevzettler/gatsby-source-airtable), but due to the many breaking changes introduced, I started a new package (pretty much a complete rewrite). With the introduction of Gatsby v2, we felt it was a great time to combine the namespaces and this repository will be used moving forward. If you are looking for the documentation on `gatsby-source-airtable-linked`, see the additional branch. We do recommend moving your dependency over to this plugin, `gatsby-source-airtable`, for Gatsby v2. (If you are still on Gatsby v1, see `gatsby-source-airtable-linked` for compatibile code.)
 
 ## Install
 
@@ -17,13 +18,9 @@ or via yarn
 
 `yarn add gatsby-source-airtable`
 
-## How to use
+## Example
 
-Below is an example showing two tables. `tables` is always specified as an array. The tables may or may not be part of the same base. If you are using a field type of `Link to a Record`, you must specify the field name in `tableLinks` (matching the name shown in Airtable, not the escaped version) for this plugin to create the graphql links for you. Otherwise, you will just receive the Airtable IDs as `strings`. Functionally, Airtable stores the `Link to a Record` fields with IDs pointing to the other tables. When you specify the column name in `tableLinks`, you are signifying to this plugin that that column/field has IDs and you want these IDs linked to the real data that is also in graphql. The name of the column/field does not have to match the related base, but you do need to make sure that the related base is included in your `gatsby-config.js` as well. (We can't link to something that doesn't exist!)
-
-Additionally you may optionally provide a "mapping". This will alert the plugin that column names you specify are of a specific, non-string format. This is particularly useful if you would like to have gatsby pick up the fields for transforming, e.g. `text/markdown`. If you do not provide a mapping, Gatsby will just "infer" what type of value it is, which is most typically a `string`.
-
-Additionally, if you are using the `Attachment` type field in Airtable, you may specify a column name with `fileNode` and the plugin will bring in these files. Using this method, it will create "nodes" for each of the files and expose this to all of the transformer plugins. A good use case for this would be attaching images in Airtable, and being able to make these available for use with the `sharp` plugins and `gatsby-image`. Specifying a `fileNode` does require a peer dependency of `gatsby-source-filesystem` otherwise it will fall back as a non-mapped field. The locally available files and any ecosystem connections will be available on the node as `localFiles`.
+Getting data from two different tables:
 
 ```javascript
 // In gatsby-config.js
@@ -35,50 +32,35 @@ plugins: [
       tables: [
         {
           baseId: `YOUR_AIRTABLE_BASE_ID`,
-          tableName: `YOUR_AIRTABLE_NAME`,
-          tableView: `YOUR_AIRTABLE_VIEW_NAME`,
+          tableName: `YOUR_TABLE_NAME`,
+          tableView: `YOUR_TABLE_VIEW_NAME`,
           queryName: `OPTIONAL_NAME_TO_IDENTIFY_TABLE`, // optional
-          mapping: {'COLUMN NAME AS SEEN IN AIRTABLE': `VALUE_FORMAT`}, // optional
-          tableLinks: [`ARRAY_OF_STRINGS_REPRESENTING_COLUMN_NAMES`] // optional
+          mapping: { `CASE_SENSITIVE_COLUMN_NAME`: `VALUE_FORMAT` }, // optional, e.g. "text/markdown", "fileNode"
+          tableLinks: [`CASE`, `SENSITIVE`, `COLUMN`, `NAMES`] // optional, for deep linking to records across tables.
         },
         {
           baseId: `YOUR_AIRTABLE_BASE_ID`,
-          tableName: `YOUR_AIRTABLE_NAME`,
-          tableView: `YOUR_AIRTABLE_VIEW_NAME`
+          tableName: `YOUR_TABLE_NAME`,
+          tableView: `YOUR_TABLE_VIEW_NAME`
           // can leave off queryName, mapping or tableLinks if not needed
         }
       ]
     }
-  },
-]
+  }
+];
 ```
 
-Within Airtable, there exists your base which has table(s) and each table can have a view(s). A view can either be a different way to see your data, but it can also have embedded filters on your data. Specifying a view allows you to target a specific view (and possibly pre-filter if need be). If you do not specify a view, that airtable just returns the raw data in no particular order.
-
-Additionally, you may have a situation where you are including two separate bases each with a table that has the exact same name. With the data structure of this repo, both bases would fall into allAirtable and you wouldn't be able to tell which from which table each record came. If you need to filter your records down to a specfic table in this situation, you can specify a `queryName` with which to accomplish this. This is only to help separate these records within your gatsby repository. See the How To Query section for an example of filtering.
-
-## API Key
-
-The API key can be specified in `gatsby-config.js` as noted in the previous section. Unfortunately, this exposes your key in your repository which is not great if especially if it is public. In addition, you may specify your API key using an [Environment Variable](https://www.gatsbyjs.org/docs/environment-variables/). This plugin looks for an environment variable called `GATSBY_AIRTABLE_API_KEY` and will use it prior to resorting to the `apiKey` defined in `gatsby-config.js`.
-
-Note: If you add or your change your API key in an environment variable at the system level, you may need to reload your code editor / IDE for that variable to reload. You may also specify it in your command line such as `GATSBY_AIRTABLE_API_KEY=XXXXXX gatsby develop`.
-
-## How to Query
-
-If you are looking for an array of rows, your query may look like below. You can optionally filter based on the table name, etc. if you only want rows from specific tables and/or bases.
+Get one single record (table row), where `Field_1 === YOUR_VALUE`
 
 ```
 {
-  allAirtable(filter: {table: {eq: "Table 1"}}) {
-    edges {
-      node {
-        id
+  airtable(table: {eq: "YOUR_TABLE_NAME"}, data: {Field_1: {eq: "YOUR_VALUE"}}) {
+    data {
+      Field_1
+      Field_2
+      Linked_Field {
         data {
-          Column_Names_Matching_Tables
-          A_Linked_Field {
-            id
-            data {etc_data_fields}
-          }
+          Linked_Field_1
         }
       }
     }
@@ -86,14 +68,63 @@ If you are looking for an array of rows, your query may look like below. You can
 }
 ```
 
-If you are looking for a single record, your query may look like below. It will always only return one record. You can filter down to one specific record as shown in the example. Otherwise, if your filters would return more than one record, it will instead only return the first record.
+Get all records from `YOUR_TABLE_NAME` where `Field_1 === YOUR_VALUE`
 
 ```
 {
-  airtable(table: {eq: "Table 1"}, data: {Column_Names_Matching_Tables: {eq: "test2"}}) {
-		data {
-		  Column_Names_Matching_Tables
-		}
+  allAirtable(filter: {table: {eq: "YOUR_TABLE_NAME"}, data: {Field_1: {eq: "YOUR_VALUE"}}}) {
+    edges {
+      node {
+        data {
+          Field_1
+          ...
+        }
+      }
+    }
   }
 }
 ```
+
+## How it works
+
+When running `gatsby develop` or `gatsby build`, this plugin will fetch all data for all rows in each of the tables you specify, making them available for query throughout your gatsby.js app, and to other gatsby plugins as well.
+
+As seen in the example above, `tables` is always specified as an array of table objects. These tables may be sourced from different bases.
+
+Querying for `airtable` will always only return one record (defaulting to the first record in the table), and querying for `allAirtable` will return any records that match your query parameters.
+
+As in the examples above, you can narrow your query by filtering for table names, and field values.
+
+### Deep linking across tables
+
+One powerful feature of Airtable is the ability to specify fields which link to records in other tables-- the `Link to a Record` field type. If you wish to query data from a linked record, you must specify the field name in `tableLinks` (matching the name shown in Airtable, not the escaped version).
+
+This will create nested nodes accessible in your graphQL queries, as shown in the above example. If you do not specify a linked field in `tableLinks`, you will just receive the linked record's Airtable IDs as `strings`. The name of the column/field does not have to match the related table, but you do need to make sure that the related table is included as an object in your `gatsby-config.js` as well.
+
+### Using markdown and attachments
+
+Optionally, you may provide a "mapping". This will alert the plugin that column names you specify are of a specific, non-string format of your choosing. This is particularly useful if you would like to have gatsby pick up the fields for transforming, e.g. `text/markdown`. If you do not provide a mapping, Gatsby will just "infer" what type of value it is, which is most typically a `string`.
+
+For an example of a markdown-and-airtable driven site using `gatsby-transformer-remark`, see the examples folder in this repo.
+
+If you are using the `Attachment` type field in Airtable, you may specify a column name with `fileNode` and the plugin will bring in these files. Using this method, it will create "nodes" for each of the files and expose this to all of the transformer plugins. A good use case for this would be attaching images in Airtable, and being able to make these available for use with the `sharp` plugins and `gatsby-image`. Specifying a `fileNode` does require a peer dependency of `gatsby-source-filesystem` otherwise it will fall back as a non-mapped field. The locally available files and any ecosystem connections will be available on the node as `localFiles`.
+
+### The power of views
+
+Within Airtable, every table can have one or more named Views. These Views are a convenient way to pre-filter and sort your data before querying it in Gatsby. If you do not specify a view in your table object, raw data will be returned in no particular order.
+
+For example, if you are creating a blog or documentation site, specify a `published` field in Airtable, create a filter showing only published posts, and specify this as `tableView` in `gatsby-config.js`
+
+### Naming conflicts
+
+You may have a situation where you are including two separate bases, each with a table that has the exact same name. With the data structure of this repo, both bases would fall into allAirtable and you wouldn't be able to tell them apart when building graphQL queries. This is what the optional `queryName` setting is for-- simply to provide an alternate name for a table.
+
+### API Keys
+
+Keys can be found in Airtable by clicking `Help > API Documentation`.
+
+The API key can be specified in `gatsby-config.js` as noted in the previous section-- **this exposes your key to anyone viewing your repository and is not recommended**.
+
+Alternatively, you may specify your API key using an [Environment Variable](https://www.gatsbyjs.org/docs/environment-variables/). This plugin looks for an environment variable called `GATSBY_AIRTABLE_API_KEY` and will use it prior to resorting to the `apiKey` defined in `gatsby-config.js`. You may also specify it in your command line such as `GATSBY_AIRTABLE_API_KEY=XXXXXX gatsby develop`.
+
+If you add or your change your API key in an environment variable at the system level, you may need to reload your code editor / IDE for that variable to reload.

--- a/examples/markdown-docs/gatsby-config.js
+++ b/examples/markdown-docs/gatsby-config.js
@@ -7,17 +7,17 @@ module.exports = {
     {
       resolve: `gatsby-source-airtable`,
       options: {
-        // apiKey: `YOUR_API_KEY`,
+        // apiKey: `YOUR_API_KEY`, (set via environment variable for this example)
         tables: [
           {
-            // baseId: `YOUR_BASE_ID`,
+            baseId: `tblXeAbfG2hYTomd3`,
             tableName: `Sections`,
             tableView: `All`,
             mapping: { Body: 'text/markdown' },
             tableLinks: [`Pages`],
           },
           {
-            // baseId: `YOUR_BASE_ID`,
+            baseId: `tblXeAbfG2hYTomd3`,
             tableName: `Pages`,
             tableView: `All`,
             mapping: { Body: 'text/markdown' },

--- a/examples/markdown-docs/gatsby-config.js
+++ b/examples/markdown-docs/gatsby-config.js
@@ -10,14 +10,14 @@ module.exports = {
         // apiKey: `YOUR_API_KEY`, (set via environment variable for this example)
         tables: [
           {
-            baseId: `tblXeAbfG2hYTomd3`,
+            baseId: `appN0O40W9X0mzbsl`,
             tableName: `Sections`,
             tableView: `All`,
             mapping: { Body: 'text/markdown' },
             tableLinks: [`Pages`],
           },
           {
-            baseId: `tblXeAbfG2hYTomd3`,
+            baseId: `appN0O40W9X0mzbsl`,
             tableName: `Pages`,
             tableView: `All`,
             mapping: { Body: 'text/markdown' },

--- a/examples/markdown-docs/gatsby-config.js
+++ b/examples/markdown-docs/gatsby-config.js
@@ -1,0 +1,30 @@
+module.exports = {
+  siteMetadata: {
+    title: 'My Documentation Site',
+  },
+  plugins: [
+    `gatsby-transformer-remark`,
+    {
+      resolve: `gatsby-source-airtable`,
+      options: {
+        apiKey: `key9QODPlAzbuqeKR`,
+        tables: [
+          {
+            baseId: `appRTpunNujtlkzY4`,
+            tableName: `Sections`,
+            tableView: `All`,
+            mapping: { Body: 'text/markdown' },
+            tableLinks: [`Pages`],
+          },
+          {
+            baseId: `appRTpunNujtlkzY4`,
+            tableName: `Pages`,
+            tableView: `All`,
+            mapping: { Body: 'text/markdown' },
+            tableLinks: [`Section`],
+          },
+        ],
+      },
+    },
+  ],
+}

--- a/examples/markdown-docs/gatsby-config.js
+++ b/examples/markdown-docs/gatsby-config.js
@@ -7,17 +7,17 @@ module.exports = {
     {
       resolve: `gatsby-source-airtable`,
       options: {
-        apiKey: `key9QODPlAzbuqeKR`,
+        // apiKey: `YOUR_API_KEY`,
         tables: [
           {
-            baseId: `appRTpunNujtlkzY4`,
+            // baseId: `YOUR_BASE_ID`,
             tableName: `Sections`,
             tableView: `All`,
             mapping: { Body: 'text/markdown' },
             tableLinks: [`Pages`],
           },
           {
-            baseId: `appRTpunNujtlkzY4`,
+            // baseId: `YOUR_BASE_ID`,
             tableName: `Pages`,
             tableView: `All`,
             mapping: { Body: 'text/markdown' },

--- a/examples/markdown-docs/gatsby-node.js
+++ b/examples/markdown-docs/gatsby-node.js
@@ -1,0 +1,42 @@
+const path = require(`path`)
+
+exports.createPages = ({ graphql, actions }) => {
+  // createPage is a built in action,
+  // available to all gatsby-node exports
+  const { createPage } = actions
+  return new Promise(async resolve => {
+    // we need the table name (e.g. "Sections")
+    // as well as the unique path for each Page/Section.
+    const result = await graphql(`
+      {
+        allAirtable {
+          edges {
+            node {
+              table
+              data {
+                Path
+              }
+            }
+          }
+        }
+      }
+    `)
+    // For each path, create a page and decide which template to use.
+    // values inside the context Object are available in the page's query
+    result.data.allAirtable.edges.forEach(({ node }) => {
+      const isPage = node.table === 'Pages'
+      createPage({
+        path: node.data.Path,
+        component: isPage
+          ? path.resolve(`./src/templates/page-template.js`)
+          : path.resolve(`./src/templates/section-template.js`),
+        context: {
+          Path: node.data.Path,
+        },
+      })
+    })
+    resolve()
+  })
+}
+
+// You can delete this file if you're not using it

--- a/examples/markdown-docs/package.json
+++ b/examples/markdown-docs/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "gatsby-starter-default",
-  "description": "Gatsby default starter",
-  "version": "1.0.0",
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "name": "markdown-docs-example",
   "dependencies": {
     "gatsby": "^2.0.19",
     "gatsby-source-airtable": "^2.0.1",
@@ -15,7 +12,6 @@
   "keywords": [
     "gatsby"
   ],
-  "license": "MIT",
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
@@ -25,8 +21,4 @@
   "devDependencies": {
     "prettier": "^1.14.2"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby-starter-default"
-  }
 }

--- a/examples/markdown-docs/package.json
+++ b/examples/markdown-docs/package.json
@@ -20,5 +20,5 @@
   },
   "devDependencies": {
     "prettier": "^1.14.2"
-  },
+  }
 }

--- a/examples/markdown-docs/package.json
+++ b/examples/markdown-docs/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "gatsby-starter-default",
+  "description": "Gatsby default starter",
+  "version": "1.0.0",
+  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "dependencies": {
+    "gatsby": "^2.0.19",
+    "gatsby-source-airtable": "^2.0.1",
+    "gatsby-source-filesystem": "^2.0.3",
+    "gatsby-transformer-remark": "^2.1.7",
+    "react": "^16.5.1",
+    "react-dom": "^16.5.1",
+    "remark-html": "^8.0.0"
+  },
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "build": "gatsby build",
+    "develop": "gatsby develop",
+    "format": "prettier --write '**/*.js'",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "devDependencies": {
+    "prettier": "^1.14.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby-starter-default"
+  }
+}

--- a/examples/markdown-docs/readme.md
+++ b/examples/markdown-docs/readme.md
@@ -1,0 +1,5 @@
+# Markdown Docs
+This folder contains an example integrating with markdown processing.
+
+The public viewable base that this example is built on is available at the following url:
+https://airtable.com/shrgDwysD78WqScKb

--- a/examples/markdown-docs/src/components/header.js
+++ b/examples/markdown-docs/src/components/header.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Link } from 'gatsby'
+
+const Header = ({ siteTitle }) => (
+  <div
+    style={{
+      background: 'rebeccapurple',
+      marginBottom: '1.45rem',
+    }}
+  >
+    <div
+      style={{
+        margin: '0 auto',
+        maxWidth: 960,
+        padding: '1.45rem 1.0875rem',
+      }}
+    >
+      <h1 style={{ margin: 0 }}>
+        <Link
+          to="/"
+          style={{
+            color: 'white',
+            textDecoration: 'none',
+          }}
+        >
+          {siteTitle}
+        </Link>
+      </h1>
+    </div>
+  </div>
+)
+
+export default Header

--- a/examples/markdown-docs/src/components/layout.css
+++ b/examples/markdown-docs/src/components/layout.css
@@ -1,0 +1,624 @@
+html {
+  font-family: sans-serif;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+body {
+  margin: 0;
+}
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+audio,
+canvas,
+progress,
+video {
+  display: inline-block;
+}
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+progress {
+  vertical-align: baseline;
+}
+[hidden],
+template {
+  display: none;
+}
+a {
+  background-color: transparent;
+  -webkit-text-decoration-skip: objects;
+}
+a:active,
+a:hover {
+  outline-width: 0;
+}
+abbr[title] {
+  border-bottom: none;
+  text-decoration: underline;
+  text-decoration: underline dotted;
+}
+b,
+strong {
+  font-weight: inherit;
+  font-weight: bolder;
+}
+dfn {
+  font-style: italic;
+}
+h1 {
+  font-size: 2em;
+  margin: .67em 0;
+}
+mark {
+  background-color: #ff0;
+  color: #000;
+}
+small {
+  font-size: 80%;
+}
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sub {
+  bottom: -.25em;
+}
+sup {
+  top: -.5em;
+}
+img {
+  border-style: none;
+}
+svg:not(:root) {
+  overflow: hidden;
+}
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+figure {
+  margin: 1em 40px;
+}
+hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
+}
+button,
+input,
+optgroup,
+select,
+textarea {
+  font: inherit;
+  margin: 0;
+}
+optgroup {
+  font-weight: 700;
+}
+button,
+input {
+  overflow: visible;
+}
+button,
+select {
+  text-transform: none;
+}
+[type=reset],
+[type=submit],
+button,
+html [type=button] {
+  -webkit-appearance: button;
+}
+[type=button]::-moz-focus-inner,
+[type=reset]::-moz-focus-inner,
+[type=submit]::-moz-focus-inner,
+button::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+[type=button]:-moz-focusring,
+[type=reset]:-moz-focusring,
+[type=submit]:-moz-focusring,
+button:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+fieldset {
+  border: 1px solid silver;
+  margin: 0 2px;
+  padding: .35em .625em .75em;
+}
+legend {
+  box-sizing: border-box;
+  color: inherit;
+  display: table;
+  max-width: 100%;
+  padding: 0;
+  white-space: normal;
+}
+textarea {
+  overflow: auto;
+}
+[type=checkbox],
+[type=radio] {
+  box-sizing: border-box;
+  padding: 0;
+}
+[type=number]::-webkit-inner-spin-button,
+[type=number]::-webkit-outer-spin-button {
+  height: auto;
+}
+[type=search] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+[type=search]::-webkit-search-cancel-button,
+[type=search]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+::-webkit-input-placeholder {
+  color: inherit;
+  opacity: .54;
+}
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+html {
+  font: 112.5%/1.45em georgia, serif;
+  box-sizing: border-box;
+  overflow-y: scroll;
+}
+* {
+  box-sizing: inherit;
+}
+*:before {
+  box-sizing: inherit;
+}
+*:after {
+  box-sizing: inherit;
+}
+body {
+  color: hsla(0, 0%, 0%, 0.8);
+  font-family: georgia, serif;
+  font-weight: normal;
+  word-wrap: break-word;
+  font-kerning: normal;
+  -moz-font-feature-settings: "kern", "liga", "clig", "calt";
+  -ms-font-feature-settings: "kern", "liga", "clig", "calt";
+  -webkit-font-feature-settings: "kern", "liga", "clig", "calt";
+  font-feature-settings: "kern", "liga", "clig", "calt";
+}
+img {
+  max-width: 100%;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+}
+h1 {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+  color: inherit;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-weight: bold;
+  text-rendering: optimizeLegibility;
+  font-size: 2.25rem;
+  line-height: 1.1;
+}
+h2 {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+  color: inherit;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-weight: bold;
+  text-rendering: optimizeLegibility;
+  font-size: 1.62671rem;
+  line-height: 1.1;
+}
+h3 {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+  color: inherit;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-weight: bold;
+  text-rendering: optimizeLegibility;
+  font-size: 1.38316rem;
+  line-height: 1.1;
+}
+h4 {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+  color: inherit;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-weight: bold;
+  text-rendering: optimizeLegibility;
+  font-size: 1rem;
+  line-height: 1.1;
+}
+h5 {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+  color: inherit;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-weight: bold;
+  text-rendering: optimizeLegibility;
+  font-size: 0.85028rem;
+  line-height: 1.1;
+}
+h6 {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+  color: inherit;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-weight: bold;
+  text-rendering: optimizeLegibility;
+  font-size: 0.78405rem;
+  line-height: 1.1;
+}
+hgroup {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+}
+ul {
+  margin-left: 1.45rem;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+  list-style-position: outside;
+  list-style-image: none;
+}
+ol {
+  margin-left: 1.45rem;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+  list-style-position: outside;
+  list-style-image: none;
+}
+dl {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+}
+dd {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+}
+p {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+}
+figure {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+}
+pre {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+  font-size: 0.85rem;
+  line-height: 1.42;
+  background: hsla(0, 0%, 0%, 0.04);
+  border-radius: 3px;
+  overflow: auto;
+  word-wrap: normal;
+  padding: 1.45rem;
+}
+table {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+  font-size: 1rem;
+  line-height: 1.45rem;
+  border-collapse: collapse;
+  width: 100%;
+}
+fieldset {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+}
+blockquote {
+  margin-left: 1.45rem;
+  margin-right: 1.45rem;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+}
+form {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+}
+noscript {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+}
+iframe {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+}
+hr {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: calc(1.45rem - 1px);
+  background: hsla(0, 0%, 0%, 0.2);
+  border: none;
+  height: 1px;
+}
+address {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+}
+b {
+  font-weight: bold;
+}
+strong {
+  font-weight: bold;
+}
+dt {
+  font-weight: bold;
+}
+th {
+  font-weight: bold;
+}
+li {
+  margin-bottom: calc(1.45rem / 2);
+}
+ol li {
+  padding-left: 0;
+}
+ul li {
+  padding-left: 0;
+}
+li > ol {
+  margin-left: 1.45rem;
+  margin-bottom: calc(1.45rem / 2);
+  margin-top: calc(1.45rem / 2);
+}
+li > ul {
+  margin-left: 1.45rem;
+  margin-bottom: calc(1.45rem / 2);
+  margin-top: calc(1.45rem / 2);
+}
+blockquote *:last-child {
+  margin-bottom: 0;
+}
+li *:last-child {
+  margin-bottom: 0;
+}
+p *:last-child {
+  margin-bottom: 0;
+}
+li > p {
+  margin-bottom: calc(1.45rem / 2);
+}
+code {
+  font-size: 0.85rem;
+  line-height: 1.45rem;
+}
+kbd {
+  font-size: 0.85rem;
+  line-height: 1.45rem;
+}
+samp {
+  font-size: 0.85rem;
+  line-height: 1.45rem;
+}
+abbr {
+  border-bottom: 1px dotted hsla(0, 0%, 0%, 0.5);
+  cursor: help;
+}
+acronym {
+  border-bottom: 1px dotted hsla(0, 0%, 0%, 0.5);
+  cursor: help;
+}
+abbr[title] {
+  border-bottom: 1px dotted hsla(0, 0%, 0%, 0.5);
+  cursor: help;
+  text-decoration: none;
+}
+thead {
+  text-align: left;
+}
+td,
+th {
+  text-align: left;
+  border-bottom: 1px solid hsla(0, 0%, 0%, 0.12);
+  font-feature-settings: "tnum";
+  -moz-font-feature-settings: "tnum";
+  -ms-font-feature-settings: "tnum";
+  -webkit-font-feature-settings: "tnum";
+  padding-left: 0.96667rem;
+  padding-right: 0.96667rem;
+  padding-top: 0.725rem;
+  padding-bottom: calc(0.725rem - 1px);
+}
+th:first-child,
+td:first-child {
+  padding-left: 0;
+}
+th:last-child,
+td:last-child {
+  padding-right: 0;
+}
+tt,
+code {
+  background-color: hsla(0, 0%, 0%, 0.04);
+  border-radius: 3px;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
+  padding: 0;
+  padding-top: 0.2em;
+  padding-bottom: 0.2em;
+}
+pre code {
+  background: none;
+  line-height: 1.42;
+}
+code:before,
+code:after,
+tt:before,
+tt:after {
+  letter-spacing: -0.2em;
+  content: " ";
+}
+pre code:before,
+pre code:after,
+pre tt:before,
+pre tt:after {
+  content: "";
+}
+@media only screen and (max-width: 480px) {
+  html {
+    font-size: 100%;
+  }
+}

--- a/examples/markdown-docs/src/components/layout.js
+++ b/examples/markdown-docs/src/components/layout.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Helmet from 'react-helmet'
 import { StaticQuery, graphql } from 'gatsby'
 
 import Header from './header'
@@ -19,15 +18,6 @@ const Layout = ({ children }) => (
     `}
     render={data => (
       <>
-        <Helmet
-          title={data.site.siteMetadata.title}
-          meta={[
-            { name: 'description', content: 'Sample' },
-            { name: 'keywords', content: 'sample, something' },
-          ]}
-        >
-          <html lang="en" />
-        </Helmet>
         <Header siteTitle={data.site.siteMetadata.title} />
         <div
           style={{

--- a/examples/markdown-docs/src/components/layout.js
+++ b/examples/markdown-docs/src/components/layout.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Helmet from 'react-helmet'
+import { StaticQuery, graphql } from 'gatsby'
+
+import Header from './header'
+import './layout.css'
+
+const Layout = ({ children }) => (
+  <StaticQuery
+    query={graphql`
+      query SiteTitleQuery {
+        site {
+          siteMetadata {
+            title
+          }
+        }
+      }
+    `}
+    render={data => (
+      <>
+        <Helmet
+          title={data.site.siteMetadata.title}
+          meta={[
+            { name: 'description', content: 'Sample' },
+            { name: 'keywords', content: 'sample, something' },
+          ]}
+        >
+          <html lang="en" />
+        </Helmet>
+        <Header siteTitle={data.site.siteMetadata.title} />
+        <div
+          style={{
+            margin: '0 auto',
+            maxWidth: 960,
+            padding: '0px 1.0875rem 1.45rem',
+            paddingTop: 0,
+          }}
+        >
+          {children}
+        </div>
+      </>
+    )}
+  />
+)
+
+Layout.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+export default Layout

--- a/examples/markdown-docs/src/pages/404.js
+++ b/examples/markdown-docs/src/pages/404.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import Layout from '../components/layout'
+
+const NotFoundPage = () => (
+  <Layout>
+    <h1>NOT FOUND</h1>
+    <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+  </Layout>
+)
+
+export default NotFoundPage

--- a/examples/markdown-docs/src/pages/index.js
+++ b/examples/markdown-docs/src/pages/index.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Link, graphql } from 'gatsby'
+
+import Layout from '../components/layout'
+
+const IndexPage = ({ data }) => (
+  <Layout>
+    <h1>Table of Contents</h1>
+    {data.allAirtable.edges.map((edge, i) => (
+      <Link to={edge.node.data.Path} key={i}>
+        <h3>{edge.node.data.Title}</h3>
+      </Link>
+    ))}
+  </Layout>
+)
+
+export default IndexPage
+
+export const query = graphql`
+  {
+    allAirtable(filter: { table: { eq: "Sections" } }) {
+      edges {
+        node {
+          data {
+            Title
+            Path
+          }
+        }
+      }
+    }
+  }
+`

--- a/examples/markdown-docs/src/templates/page-template.js
+++ b/examples/markdown-docs/src/templates/page-template.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Link, graphql } from 'gatsby'
+import Layout from '../components/layout'
+
+export default ({ data }) => (
+  <Layout>
+    <Link to={data.airtable.data.Section[0].data.Path}>
+      <h6>> {data.airtable.data.Section[0].data.Title}</h6>
+    </Link>
+    <h3>{data.airtable.data.Title}</h3>
+    <main
+      dangerouslySetInnerHTML={{
+        __html: data.airtable.data.Body.childMarkdownRemark.html,
+      }}
+    />
+  </Layout>
+)
+
+export const query = graphql`
+  query GetPage($Path: String!) {
+    airtable(table: { eq: "Pages" }, data: { Path: { eq: $Path } }) {
+      data {
+        Title
+        Body {
+          childMarkdownRemark {
+            html
+          }
+        }
+        Section {
+          data {
+            Title
+            Path
+          }
+        }
+      }
+    }
+  }
+`

--- a/examples/markdown-docs/src/templates/section-template.js
+++ b/examples/markdown-docs/src/templates/section-template.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import { Link, graphql } from 'gatsby'
+import Layout from '../components/layout'
+
+export default ({ data }) => (
+  <Layout>
+    <h3>{data.airtable.data.Title}</h3>
+    <main
+      dangerouslySetInnerHTML={{
+        __html: data.airtable.data.Body.childMarkdownRemark.html,
+      }}
+    />
+    {data.airtable.data.Pages.map((page, i) => (
+      <Link to={page.data.Path} key={i}>
+        <h4>{page.data.Title}</h4>
+      </Link>
+    ))}
+  </Layout>
+)
+
+export const query = graphql`
+  query GetSection($Path: String!) {
+    airtable(table: { eq: "Sections" }, data: { Path: { eq: $Path } }) {
+      data {
+        Title
+        Body {
+          childMarkdownRemark {
+            html
+          }
+        }
+        Pages {
+          data {
+            Title
+            Path
+          }
+        }
+      }
+    }
+  }
+`

--- a/examples/recipes-with-photos/gatsby-config.js
+++ b/examples/recipes-with-photos/gatsby-config.js
@@ -22,20 +22,20 @@ module.exports = {
       options: {
         tables: [
           {
-            baseId: `appcL6Jdj7ZrhTg4q`,
+            baseId: `tbl1zhB7g2q3NXALg`,
             tableName: `Recipes`,
             tableView: `List`,
             mapping: { Attachments: `fileNode` },
             tableLinks: [`Cooking Method`, `Style`]
           },
           {
-            baseId: `appcL6Jdj7ZrhTg4q`,
+            baseId: `tbl1zhB7g2q3NXALg`,
             tableName: `Cooking Method`,
             tableView: `Main View`,
             tableLinks: [`Recipes`]
           },
           {
-            baseId: `appcL6Jdj7ZrhTg4q`,
+            baseId: `tbl1zhB7g2q3NXALg`,
             tableName: `Style`,
             tableView: `Main View`,
             tableLinks: [`Recipes`]
@@ -44,6 +44,6 @@ module.exports = {
       }
     },
     `gatsby-transformer-sharp`,
-    "gatsby-plugin-react-helmet"
+    `gatsby-plugin-react-helmet`
   ]
 };

--- a/examples/recipes-with-photos/gatsby-config.js
+++ b/examples/recipes-with-photos/gatsby-config.js
@@ -22,20 +22,20 @@ module.exports = {
       options: {
         tables: [
           {
-            baseId: `tbl1zhB7g2q3NXALg`,
+            baseId: `appM8D8wmSJX9WJDE`,
             tableName: `Recipes`,
             tableView: `List`,
             mapping: { Attachments: `fileNode` },
             tableLinks: [`Cooking Method`, `Style`]
           },
           {
-            baseId: `tbl1zhB7g2q3NXALg`,
+            baseId: `appM8D8wmSJX9WJDE`,
             tableName: `Cooking Method`,
             tableView: `Main View`,
             tableLinks: [`Recipes`]
           },
           {
-            baseId: `tbl1zhB7g2q3NXALg`,
+            baseId: `appM8D8wmSJX9WJDE`,
             tableName: `Style`,
             tableView: `Main View`,
             tableLinks: [`Recipes`]

--- a/examples/recipes-with-photos/readme.md
+++ b/examples/recipes-with-photos/readme.md
@@ -1,0 +1,5 @@
+# Recipes with Photos
+This folder contains an example integrating records with photo attachments.
+
+The public viewable base that this example is built on is available at the following url:
+https://airtable.com/shrdDVGtwde5feCLq


### PR DESCRIPTION
#### Example
Here is a very simple markdown example, a "docs" site of sorts. It demonstrates Page docs nested inside Section docs, and a Table of Contents at the root. Each page/section is a row in airtable. If I ever find a better solution for referencing images in markdown (atm I'm just using remote URLs), then I will update the example accordingly.

Here is the Airtable template it pulls from. Is it difficult to clone this base to your own account? I haven't tried doing that yet.
https://airtable.com/shr4i6YRjnyRK0WYO

I also wrote a step-by-step beginners tutorial on Medium while building this-- I will wait for release so I can reference the example in the article (and so that the markdown stringify issue is fixed). I think Airtable + Gatsby + Markdown is a really neat combo so I wanted to share.

#### Readme
I also updated the readme to clarify some issues I found confusing as a noob developer, and did a bit of reformatting.