### PR TITLE
Allow typeName and raw values to be configured for far greater robustness. 

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -147,9 +147,21 @@ const processData = async (row, { createNodeId, createNode, store, cache }) => {
     // these will be airtable IDs
     if (tableLinks && tableLinks.includes(key)) {
       useKey = `${cleanKey(key)}___NODE`;
-      processedData[useKey] = data[key].map(id =>
-        createNodeId(`Airtable_${id}`)
-      );
+
+      try {
+        processedData[useKey] = data[key].map(id =>
+          createNodeId(`Airtable_${id}`)
+        );
+      }
+      catch (err) {
+        console.warn(`
+          WARNING: A failed lookup occurred for for a field named '${key}' in the table '${row.tableName}'.
+          You may have tried to configure a table link for a field which is NOT a linked record field type in Airtable.
+          Please check the '${key}' column in Airtable and change its field type to 'Link to another record',
+          otherwise this may cause unexpected problems with your build or site.
+        `);
+      }
+      
       // A child node comes from the mapping, where we want to
       // define a separate node in gatsby that is available
       // for transforming. This will let other plugins pick

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -155,7 +155,7 @@ const processData = async (row, { createNodeId, createNode, store, cache }) => {
       }
       catch (err) {
         console.warn(`
-          WARNING: A failed lookup occurred for for a field named '${key}' in the table '${row.tableName}'.
+          WARNING: A failed lookup occurred for a field named '${key}' in the table '${row.tableName}'.
           You may have tried to configure a table link for a field which is NOT a linked record field type in Airtable.
           Please check the '${key}' column of '${row.tableName}' in Airtable and change its field type to 'Link to another record',
           otherwise this may cause unexpected problems with your build or site.

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -157,7 +157,7 @@ const processData = async (row, { createNodeId, createNode, store, cache }) => {
         console.warn(`
           WARNING: A failed lookup occurred for for a field named '${key}' in the table '${row.tableName}'.
           You may have tried to configure a table link for a field which is NOT a linked record field type in Airtable.
-          Please check the '${key}' column in Airtable and change its field type to 'Link to another record',
+          Please check the '${key}' column of '${row.tableName}' in Airtable and change its field type to 'Link to another record',
           otherwise this may cause unexpected problems with your build or site.
         `);
       }


### PR DESCRIPTION
Addresses #25.

This PR includes three enhancements, which make this plugin much more robust for advanced use-cases:

## Allow `typeName` to be specified for each table definition

`typeName` can now be configured for each table definition, which causes the GraphQL nodes to be defined via their own unique type names for each table configured in `gatsby-config.js`.
 
Adding the `typeName` avoids the problem where any two tables with the same field names but different data types will conflict with each other ( issue #25 ), which will create a lot of fairly unclear warnings when generating Gatsby nodes.

`typeName` is specified on a table-by-table basis, and if not present the standard ‘Airtable’ is used as before. For example, suppose we have two tables in AirTable called "Pages" to store a set of pages you want rendered in Gatsby, and each can have a "Person" linked to them, to display some kind of author perhaps. Then our config could look like:

    {
      baseId: [AIRTABLE_BASE_ID],
      tableName: `Pages`,
      typeName: 'AirtablePage',
      tableView: `Grid view`,
      tableLinks: [
        `Person`,
      ],
      mapping: {
        Content: 'text/markdown',
      }
    },
    {
      baseId: [AIRTABLE_BASE_ID],
      tableName: `People`,
      typeName: 'AirtablePerson',
      tableView: `Grid view`,
      tableLinks: [
        `Page`,
      ],
    },

This also has the superb side-effect of making GraphiQL much nicer, as the fields are no longer all mixed together between tables - you only see fields which are specific to **each** table, which is how I believe something like `gatsby-source-contentful` works already. 

## Raw value switches 

The storage of raw values also causes a few cryptic warnings when the values of rows differ, so this commit also allows raw values to be switched off either globally:

    {
      resolve: `gatsby-source-airtable`,
      options: {
        apiKey: `API_KEY`, // may instead specify via env, see below
        rawValues: false,
        tables: [
          ... etc 
        ]
      }
    }

... or on a table-by-table basis:

    {
      baseId: [AIRTABLE_BASE_ID],
      tableName: `Pages`,
      typeName: 'AirtablePage',
      tableView: `Grid view`,
      tableLinks: [
        `Person`,
      ],
      mapping: {
        Content: 'text/markdown',
      }
    },
    {
      baseId: [AIRTABLE_BASE_ID],
      tableName: `Person`,
      rawValues: false,
      typeName: 'AirtablePerson',
      tableView: `Grid view`,
      tableLinks: [
        `Page`,
      ],
    }


By default, they will be stored as before.

## Linked Fields issue

This PR also adds a `try/catch` around a piece of code used when processing linked fields - I found another very hard to debug issue occurs when you try to add a table link for a field which is **not** a linked record type. The `try/catch` block actually seems to work around this, but also logs a warning for the developer to fix the issue, as it could cause unexpected results. I couldn't quite parse how this code works, so I would be grateful for a bit of clarity around _exactly why_ this `try/catch` fixes the issue.

Let me know if you'd prefer these issues split into three PRs - they're all semi-related, but understand if we'd prefer them split up. I'm using this version of the plugin in a fairly complicated Airtable setup and it works really well now. So well, I almost think some of these settings should maybe even be defaults - but we'll leave that up for discussion as it would cause back-compat issues.  