### PR TITLE
Added rowId field to airtable node

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -98,7 +98,7 @@ exports.sourceNodes = async (
       id: createNodeId(`Airtable_${row.id}`),
       parent: null,
       table: row._table.name,
-      rowId: row.id,
+      recordId: row.id,
       queryName: row.queryName,
       children: [],
       internal: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -98,6 +98,7 @@ exports.sourceNodes = async (
       id: createNodeId(`Airtable_${row.id}`),
       parent: null,
       table: row._table.name,
+      rowId: row.id,
       queryName: row.queryName,
       children: [],
       internal: {


### PR DESCRIPTION
We had a use case where we needed the actual row ID from airtable. This pull adds a new `rowId` field to the Airtable nodes.