### PR TITLE
fix: native Promise.all doesn't handle non-iterables

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -162,7 +162,7 @@ exports.sourceNodes = async (
     )
   );
 
-  return Promise.all(flattenedChildNodes).then(nodes => {
+  return flattenedChildNodes.then(nodes => {
     nodes.forEach(node => createNode(node));
   });
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -155,14 +155,14 @@ exports.sourceNodes = async (
     return processedData.childNodes;
   });
 
-  let flattenedChildNodes = Promise.all(childNodes).then(nodes =>
+  let flattenedChildNodes = await Promise.all(childNodes).then(nodes =>
     nodes.reduce(
       (accumulator, currentValue) => accumulator.concat(currentValue),
       []
     )
   );
 
-  return flattenedChildNodes.then(nodes => {
+  return Promise.all(flattenedChildNodes).then(nodes => {
     nodes.forEach(node => createNode(node));
   });
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -277,7 +277,8 @@ const localFileCheck = async (
       });
       // Adds a field `localFile` to the node
       // ___NODE tells Gatsby that this field will link to another nodes
-      let localFiles = await Promise.all(fileNodes).map(
+      const resolvedFileNodes = await Promise.all(fileNodes);
+      const localFiles = resolvedFileNodes.map(
         attachmentNode => attachmentNode.id
       );
       return localFiles;


### PR DESCRIPTION
As mentioned in https://github.com/jbolda/gatsby-source-airtable/issues/44, we recently removed bluebird's Promise polyfill from gatsby's node code. Right now the issue is caused because
https://github.com/jbolda/gatsby-source-airtable/blob/af5d379989edaae54c8eee2f81ee1256202faebc/gatsby-node.js#L158-L163
returns single Promise that resolves to an array.

Trying to use that single Promise as argument to NodeJS's native `Promise.all` cause `#<Promise> is not an iterator` error. Seems like `bluebird`'s polyfill was more permissive in this regard.

I will discuss with team if we should revert https://github.com/gatsbyjs/gatsby/pull/12691 . But in meantime this fix will work both with native Promise and bluebird Promise.

fixes #44