### PR TITLE
Limit concurrency of remote file requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ For an example of a markdown-and-airtable-driven site using `gatsby-transformer-
 
 If you are using the `Attachment` type field in Airtable, you may specify a column name with `fileNode` and the plugin will bring in these files. Using this method, it will create "nodes" for each of the files and expose this to all of the transformer plugins. A good use case for this would be attaching images in Airtable, and being able to make these available for use with the `sharp` plugins and `gatsby-image`. Specifying a `fileNode` does require a peer dependency of `gatsby-source-filesystem` otherwise it will fall back as a non-mapped field. The locally available files and any ecosystem connections will be available on the node as `localFiles`.
 
+When using the `Attachment` type field, requests to download the associated files are limited to 5 concurrent requests to avoid excessive requests to Airtable’s servers resulting in refused connections. This limit can be set with the `concurrency` option in your `gatsby-config.js` file. Set the option with an integer value for your desired limit on attempted concurrent requests. A value of `0` will allow requests to be made with no limit.
+
 ### The power of views
 
 Within Airtable, every table can have one or more named Views. These Views are a convenient way to pre-filter and sort your data before querying it in Gatsby. If you do not specify a view in your table object, raw data will be returned in no particular order.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For an example of a markdown-and-airtable-driven site using `gatsby-transformer-
 
 If you are using the `Attachment` type field in Airtable, you may specify a column name with `fileNode` and the plugin will bring in these files. Using this method, it will create "nodes" for each of the files and expose this to all of the transformer plugins. A good use case for this would be attaching images in Airtable, and being able to make these available for use with the `sharp` plugins and `gatsby-image`. Specifying a `fileNode` does require a peer dependency of `gatsby-source-filesystem` otherwise it will fall back as a non-mapped field. The locally available files and any ecosystem connections will be available on the node as `localFiles`.
 
-When using the `Attachment` type field, requests to download the associated files are limited to 5 concurrent requests to avoid excessive requests to Airtable’s servers resulting in refused connections. This limit can be set with the `concurrency` option in your `gatsby-config.js` file. Set the option with an integer value for your desired limit on attempted concurrent requests. A value of `0` will allow requests to be made with no limit.
+When using the Attachment type field, this plugin governs requests to download the associated files from Airtable to 5 concurrent requests to prevent excessive requests on Airtable's servers - which can result in refused / hanging connections. You can adjust this limit with the concurrency option in your gatsby-config.js file. Set the option with an integer value for your desired limit on attempted concurrent requests. A value of 0 will allow requests to be made without any limit.
 
 ### The power of views
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,10 +1,11 @@
 const Airtable = require("airtable");
 const crypto = require(`crypto`);
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`);
+const { map } = require('bluebird');
 
 exports.sourceNodes = async (
   { actions, createNodeId, store, cache },
-  { apiKey, tables }
+  { apiKey, tables, concurrency }
 ) => {
   // tables contain baseId, tableName, tableView, queryName, mapping, tableLinks
   const { createNode, setPluginStatus } = actions;
@@ -28,6 +29,15 @@ exports.sourceNodes = async (
       "\ntables is not defined for gatsby-source-airtable in gatsby-config.js"
     );
     return;
+  }
+
+  if (concurrency === undefined) {
+    // There is not documentation from Airtable regarding what the rate limit
+    // against their attachment servers. Their rate limit for the API server is 
+    // 5 requests/sec, so the default limit of 5 concurrent requests for remote files 
+    // has been selected in that spirit. A higher value can be set as a plugin
+    // option in gatsby-config.js
+    concurrency = 5;
   }
 
   console.time(`\nfetch all Airtable rows from ${tables.length} tables`);
@@ -119,7 +129,10 @@ exports.sourceNodes = async (
     }
   });
 
-  return Promise.map(allRows, async row => {
+  // Use the map function for arrays of promises imported from Bluebird.
+  // Using the concurrency option protects against being blocked from Airtable's
+  // file attachment servers for large numbers of requests.
+  return map(allRows, async row => {
     // don't love mutating the row here, but
     // not ready to refactor yet to clean this up
     // (happy to take a PR!)
@@ -156,7 +169,7 @@ exports.sourceNodes = async (
     await Promise.all(processedData.childNodes).then(nodes => {
       nodes.forEach(node => createNode(node));
     });
-  }, { concurrency: 100 });
+  }, { concurrency: concurrency });
 };
 
 const processData = async (

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -119,7 +119,7 @@ exports.sourceNodes = async (
     }
   });
 
-  let childNodes = allRows.map(async row => {
+  return Promise.map(allRows, async row => {
     // don't love mutating the row here, but
     // not ready to refactor yet to clean this up
     // (happy to take a PR!)
@@ -152,19 +152,11 @@ exports.sourceNodes = async (
     };
 
     createNode(node);
-    return processedData.childNodes;
-  });
 
-  let flattenedChildNodes = await Promise.all(childNodes).then(nodes =>
-    nodes.reduce(
-      (accumulator, currentValue) => accumulator.concat(currentValue),
-      []
-    )
-  );
-
-  return Promise.all(flattenedChildNodes).then(nodes => {
-    nodes.forEach(node => createNode(node));
-  });
+    await Promise.all(processedData.childNodes).then(nodes => {
+      nodes.forEach(node => createNode(node));
+    });
+  }, { concurrency: 100 });
 };
 
 const processData = async (

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -33,10 +33,9 @@ exports.sourceNodes = async (
   }
 
   if (concurrency === undefined) {
-    // There is not documentation from Airtable regarding what the rate limit
-    // against their attachment servers. Their rate limit for the API server is 
-    // 5 requests/sec, so the default limit of 5 concurrent requests for remote files 
-    // has been selected in that spirit. A higher value can be set as a plugin
+    // Airtable hasn't documented what the rate limit against their attachment servers is. 
+    // They do document that API calls are limited to 5 requests/sec, so the default limit of 5 concurrent 
+    // requests for remote files has been selected in that spirit. A higher value can be set as a plugin 
     // option in gatsby-config.js
     concurrency = 5;
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "airtable"
   ],
   "dependencies": {
-    "airtable": "^0.5.6"
+    "airtable": "^0.5.6",
+    "bluebird": "^3.5.4"
   },
   "peerDependencies": {
     "gatsby-source-filesystem": ">=2.0.0-rc.0"


### PR DESCRIPTION
Use bluebird’s Promise.map() with concurrency option to limit HTTP requests when creating remote nodes for file attachments in order to avoid being rate-limited by Airtable’s HTTP servers.