### PR TITLE
Added field prefix table option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ plugins: [
           tableName: `YOUR_TABLE_NAME`,
           tableView: `YOUR_TABLE_VIEW_NAME`, // optional
           queryName: `OPTIONAL_NAME_TO_IDENTIFY_TABLE`, // optional
+          fieldPrefix: `OPTIONAL_PREFIX_BEFORE_FIELD_NAMES` // optional, useful when multiple tables have the same field names of different types
           mapping: { `CASE_SENSITIVE_COLUMN_NAME`: `VALUE_FORMAT` }, // optional, e.g. "text/markdown", "fileNode"
           tableLinks: [`CASE`, `SENSITIVE`, `COLUMN`, `NAMES`] // optional, for deep linking to records across tables.
         },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,89 +1,109 @@
-const Airtable = require("airtable");
-const crypto = require(`crypto`);
-const { createRemoteFileNode } = require(`gatsby-source-filesystem`);
-const { map } = require('bluebird');
+const Airtable = require("airtable")
+const crypto = require(`crypto`)
+const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
+const { map } = require("bluebird")
 
 exports.sourceNodes = async (
   { actions, createNodeId, store, cache },
   { apiKey, tables, concurrency }
 ) => {
   // tables contain baseId, tableName, tableView, queryName, mapping, tableLinks
-  const { createNode, setPluginStatus } = actions;
+  const { createNode, setPluginStatus } = actions
 
   try {
     // hoist api so we can use in scope outside of this block
     if (!apiKey && process.env.GATSBY_AIRTABLE_API_KEY) {
-      console.warn("\nImplicit setting of GATSBY_AIRTABLE_API_KEY as apiKey will be deprecated in future release, apiKey should be set in gatsby-config.js, please see Readme!")
+      console.warn(
+        "\nImplicit setting of GATSBY_AIRTABLE_API_KEY as apiKey will be deprecated in future release, apiKey should be set in gatsby-config.js, please see Readme!"
+      )
     }
-    var api = await new Airtable({ apiKey: process.env.GATSBY_AIRTABLE_API_KEY || apiKey });
+    var api = await new Airtable({
+      apiKey: process.env.GATSBY_AIRTABLE_API_KEY || apiKey,
+    })
   } catch (e) {
     // airtable uses `assert` which doesn't exit the process,
     //  but rather just makes gatsby hang. Warn, don't create any
     //  nodes, but let gatsby continue working
-    console.warn("\nAPI key is required to connect to Airtable");
-    return;
+    console.warn("\nAPI key is required to connect to Airtable")
+    return
   }
 
   // exit if tables is not defined
   if (tables === undefined || tables.length === 0) {
     console.warn(
       "\ntables is not defined for gatsby-source-airtable in gatsby-config.js"
-    );
-    return;
+    )
+    return
   }
 
   if (concurrency === undefined) {
-    // Airtable hasn't documented what the rate limit against their attachment servers is. 
-    // They do document that API calls are limited to 5 requests/sec, so the default limit of 5 concurrent 
-    // requests for remote files has been selected in that spirit. A higher value can be set as a plugin 
+    // Airtable hasn't documented what the rate limit against their attachment servers is.
+    // They do document that API calls are limited to 5 requests/sec, so the default limit of 5 concurrent
+    // requests for remote files has been selected in that spirit. A higher value can be set as a plugin
     // option in gatsby-config.js
-    concurrency = 5;
+    concurrency = 5
   }
 
-  console.time(`\nfetch all Airtable rows from ${tables.length} tables`);
+  console.time(`\nfetch all Airtable rows from ${tables.length} tables`)
 
-  let queue = [];
+  let queue = []
   tables.forEach(tableOptions => {
-    let base = api.base(tableOptions.baseId);
+    let base = api.base(tableOptions.baseId)
 
-    let table = base(tableOptions.tableName);
+    let table = base(tableOptions.tableName)
 
-    let view = tableOptions.tableView || "";
+    let view = tableOptions.tableView || ""
 
+    let fieldPrefix = tableOptions.fieldPrefix || ""
+
+
+    
     let query = table.select({
-      view: view
-    });
+      view: view,
+    })
 
     // confirm that the user is using the clean keys
     // if they are not, warn them and change it for them
     // we can settle the API on clean keys and not have a breaking
     // change until the next major version when we remove this
-    const cleanMapping = !tableOptions.mapping ? null : Object.keys(tableOptions.mapping).reduce((cleaned, key) => {
-      let useKey = cleanKey(key)
-      if (useKey !== key) console.warn(`
+    const cleanMapping = !tableOptions.mapping
+      ? null
+      : Object.keys(tableOptions.mapping).reduce((cleaned, key) => {
+          let useKey = cleanKey(key)
+          if (useKey !== key)
+            console.warn(`
         Field names within graphql cannot have spaces. We do not want you to change your column names
         within Airtable, but in "Gatsby-land" you will need to always use the "cleaned" key.
-        On the ${tableOptions.tableName} base ${tableOptions.baseId} 'mapping', we modified the supplied key of
+        On the ${tableOptions.tableName} base ${
+              tableOptions.baseId
+            } 'mapping', we modified the supplied key of
         ${key} to instead be ${useKey}. Please use ${useKey} in all of your queries. Also, update your config
         to use ${useKey} to make this warning go away. See https://github.com/jbolda/gatsby-source-airtable#column-names
         for more information.
       `)
-      cleaned[useKey] = tableOptions.mapping[key]
-      return cleaned
-    }, {})
+          cleaned[useKey] = tableOptions.mapping[key]
+          return cleaned
+        }, {})
 
-    const cleanLinks = !tableOptions.tableLinks ? null : tableOptions.tableLinks.map(key => {
-      let useKey = cleanKey(key)
-      if (useKey !== key) console.warn(`
+    const cleanLinks = !tableOptions.tableLinks
+      ? null
+      : tableOptions.tableLinks.map(key => {
+          let useKey = (tableOptions.fieldPrefix) ?
+            cleanKey(tableOptions.fieldPrefix) + cleanKey(key) :
+            cleanKey(key)
+          if (useKey !== key)
+            console.warn(`
         Field names within graphql cannot have spaces. We do not want you to change your column names
         within Airtable, but in "Gatsby-land" you will need to always use the "cleaned" key.
-        On the ${tableOptions.tableName} base ${tableOptions.baseId} 'tableLinks', we modified the supplied key of
+        On the ${tableOptions.tableName} base ${
+              tableOptions.baseId
+            } 'tableLinks', we modified the supplied key of
         ${key} to instead be ${useKey}. Please use ${useKey} in all of your queries. Also, update your config
         to use ${useKey} to make this warning go away. See https://github.com/jbolda/gatsby-source-airtable#column-names
         for more information.
       `)
-      return useKey
-    })
+          return useKey
+        })
 
     // query.all() returns a promise, pass an array for each table with
     // both our promise and the queryName and then map reduce at the
@@ -94,10 +114,11 @@ exports.sourceNodes = async (
         tableOptions.queryName,
         tableOptions.defaultValues || {},
         cleanMapping,
-        cleanLinks
+        cleanLinks,
+        fieldPrefix
       ])
-    );
-  });
+    )
+  })
 
   // queue has array of promises and when resolved becomes nested arrays
   // we flatten the array to return all rows from all tables after mapping
@@ -107,100 +128,103 @@ exports.sourceNodes = async (
       return all.reduce((accumulator, currentValue) => {
         return accumulator.concat(
           currentValue[0].map(row => {
-            row.queryName = currentValue[1]; // queryName from tableOptions above
-            row.defaultValues = currentValue[2]; // mapping from tableOptions above
-            row.mapping = currentValue[3]; // mapping from tableOptions above
-            row.tableLinks = currentValue[4]; // tableLinks from tableOptions above
-            return row;
+            row.queryName = currentValue[1] // queryName from tableOptions above
+            row.defaultValues = currentValue[2] // mapping from tableOptions above
+            row.mapping = currentValue[3] // mapping from tableOptions above
+            row.tableLinks = currentValue[4] // tableLinks from tableOptions above
+            row.fieldPrefix = currentValue[5] // fieldPrefix from tableOptions above
+            return row
           })
-        );
-      }, []);
+        )
+      }, [])
     })
     .catch(e => {
-      throw e;
-      return;
-    });
+      throw e
+      return
+    })
 
-  console.timeEnd(`\nfetch all Airtable rows from ${tables.length} tables`);
+  console.timeEnd(`\nfetch all Airtable rows from ${tables.length} tables`)
 
   setPluginStatus({
     status: {
-      lastFetched: new Date().toJSON()
-    }
-  });
+      lastFetched: new Date().toJSON(),
+    },
+  })
 
   // Use the map function for arrays of promises imported from Bluebird.
   // Using the concurrency option protects against being blocked from Airtable's
   // file attachment servers for large numbers of requests.
-  return map(allRows, async row => {
-    // don't love mutating the row here, but
-    // not ready to refactor yet to clean this up
-    // (happy to take a PR!)
-    row.fields = {
-      ...row.defaultValues,
-      ...row.fields,
-    }
-    let processedData = await processData(row, {
-      createNodeId,
-      createNode,
-      store,
-      cache
-    });
+  return map(
+    allRows,
+    async row => {
+      // don't love mutating the row here, but
+      // not ready to refactor yet to clean this up
+      // (happy to take a PR!)
+      row.fields = {
+        ...row.defaultValues,
+        ...row.fields,
+      }
+      let processedData = await processData(row, {
+        createNodeId,
+        createNode,
+        store,
+        cache,
+      })
 
-    const node = {
-      id: createNodeId(`Airtable_${row.id}`),
-      parent: null,
-      table: row._table.name,
-      recordId: row.id,
-      queryName: row.queryName,
-      children: [],
-      internal: {
-        type: `Airtable`,
-        contentDigest: crypto
-          .createHash("md5")
-          .update(JSON.stringify(row))
-          .digest("hex")
-      },
-      data: processedData.data
-    };
+      const node = {
+        id: createNodeId(`Airtable_${row.id}`),
+        parent: null,
+        table: row._table.name,
+        recordId: row.id,
+        queryName: row.queryName,
+        fieldPrefix: row.fieldPrefix,
+        children: [],
+        internal: {
+          type: `Airtable`,
+          contentDigest: crypto
+            .createHash("md5")
+            .update(JSON.stringify(row))
+            .digest("hex"),
+        },
+        data: processedData.data,
+      }
 
-    createNode(node);
+      createNode(node)
 
-    await Promise.all(processedData.childNodes).then(nodes => {
-      nodes.forEach(node => createNode(node));
-    });
-  }, { concurrency: concurrency });
-};
+      await Promise.all(processedData.childNodes).then(nodes => {
+        nodes.forEach(node => createNode(node))
+      })
+    },
+    { concurrency: concurrency }
+  )
+}
 
-const processData = async (
-  row,
-  { createNodeId, createNode, store, cache }
-) => {
-  let data = row.fields;
-  let tableLinks = row.tableLinks;
-  let fieldKeys = Object.keys(data);
-  let processedData = {};
-  let childNodes = [];
-
+const processData = async (row, { createNodeId, createNode, store, cache }) => {
+  let data = row.fields
+  let tableLinks = row.tableLinks
+  let fieldKeys = Object.keys(data)
+  let processedData = {}
+  let childNodes = []
+  const cleanedKeyPrefix = (row.fieldPrefix) ? cleanKey(row.fieldPrefix) : ''
+  
   await fieldKeys.forEach(key => {
     // once in "Gatsby-land" we want to use the cleanKey
     // consistently everywhere including in configs
     // this key that we clean comes from Airtable
     // at this point, all user option keys should be clean
-    const cleanedKey = cleanKey(key)
+    const cleanedKey = cleanedKeyPrefix + cleanKey(key)
 
-    let useKey;
+    let useKey
     // deals with airtable linked fields,
     // these will be airtable IDs
     if (tableLinks && tableLinks.includes(cleanedKey)) {
-      useKey = `${cleanedKey}___NODE`;
+      useKey = `${cleanedKey}___NODE`
 
       // `data` is direct from Airtable so we don't use
       // the cleanKey here
       processedData[useKey] = data[key].map(id =>
         createNodeId(`Airtable_${id}`)
-      );
-
+      )
     } else if (row.mapping && row.mapping[cleanedKey]) {
       // A child node comes from the mapping, where we want to
       // define a separate node in gatsby that is available
@@ -212,19 +236,19 @@ const processData = async (
         createNodeId,
         createNode,
         store,
-        cache
-      });
-      childNodes.push(checkedChildNode);
+        cache,
+      })
+      childNodes.push(checkedChildNode)
     } else {
       // `data` is direct from Airtable so we don't use
       // the cleanKey here
-      processedData[cleanedKey] = data[key];
+      processedData[cleanedKey] = data[key]
     }
-  });
+  })
 
   // where childNodes returns an array of objects
-  return { data: processedData, childNodes: childNodes };
-};
+  return { data: processedData, childNodes: childNodes }
+}
 
 const checkChildNode = async (
   key,
@@ -232,19 +256,19 @@ const checkChildNode = async (
   processedData,
   { createNodeId, createNode, store, cache }
 ) => {
-  let data = row.fields;
-  let mapping = row.mapping;
-  let cleanedKey = cleanKey(key);
+  let data = row.fields
+  let mapping = row.mapping
+  let cleanedKey = cleanKey(key)
   let localFiles = await localFileCheck(key, row, {
     createNodeId,
     createNode,
     store,
-    cache
-  });
+    cache,
+  })
 
   processedData[`${cleanedKey}___NODE`] = createNodeId(
     `AirtableField_${row.id}_${cleanedKey}`
-  );
+  )
 
   return buildNode(
     localFiles,
@@ -253,20 +277,20 @@ const checkChildNode = async (
     data[key],
     mapping[key],
     createNodeId
-  );
-};
+  )
+}
 
 const localFileCheck = async (
   key,
   row,
   { createNodeId, createNode, store, cache }
 ) => {
-  let data = row.fields;
-  let mapping = row.mapping;
-  let cleanedKey = cleanKey(key);
+  let data = row.fields
+  let mapping = row.mapping
+  let cleanedKey = cleanKey(key)
   if (mapping[cleanedKey] === `fileNode`) {
     try {
-      let fileNodes = [];
+      let fileNodes = []
       // where data[key] is the array of attachments
       // `data` is direct from Airtable so we don't use
       // the cleanKey here
@@ -276,26 +300,26 @@ const localFileCheck = async (
           store,
           cache,
           createNode,
-          createNodeId
-        });
-        fileNodes.push(attachmentNode);
-      });
+          createNodeId,
+        })
+        fileNodes.push(attachmentNode)
+      })
       // Adds a field `localFile` to the node
       // ___NODE tells Gatsby that this field will link to another nodes
-      const resolvedFileNodes = await Promise.all(fileNodes);
+      const resolvedFileNodes = await Promise.all(fileNodes)
       const localFiles = resolvedFileNodes.map(
         attachmentNode => attachmentNode.id
-      );
-      return localFiles;
+      )
+      return localFiles
     } catch (e) {
       console.log(
         "You specified a fileNode, but we caught an error. First check that you have gatsby-source-filesystem installed?\n",
         e
-      );
+      )
     }
   }
-  return;
-};
+  return
+}
 
 const buildNode = (localFiles, row, cleanedKey, raw, mapping, createNodeId) => {
   if (localFiles) {
@@ -312,9 +336,9 @@ const buildNode = (localFiles, row, cleanedKey, raw, mapping, createNodeId) => {
         contentDigest: crypto
           .createHash("md5")
           .update(JSON.stringify(row))
-          .digest("hex")
-      }
-    };
+          .digest("hex"),
+      },
+    }
   } else {
     return {
       id: createNodeId(`AirtableField_${row.id}_${cleanedKey}`),
@@ -328,12 +352,12 @@ const buildNode = (localFiles, row, cleanedKey, raw, mapping, createNodeId) => {
         contentDigest: crypto
           .createHash("md5")
           .update(JSON.stringify(row))
-          .digest("hex")
-      }
-    };
+          .digest("hex"),
+      },
+    }
   }
-};
+}
 
 const cleanKey = (key, data) => {
-  return key.replace(/ /g, "_");
-};
+  return key.replace(/ /g, "_")
+}


### PR DESCRIPTION
When you have two tables in the same or different bases with the same field name, but different field types, then Graphql will not create the fields at all. We have a project where we pull from multiple bases we have little control over, and wanted to prefix the field names from different tables. This also helps prevent confusion when dealing with several different tables across projects.

This PR adds a new `fieldPrefix` option to tables that will get appended to any fields in a table. It works fine with linked table fields as well.

![table](https://user-images.githubusercontent.com/270536/56589802-52dd4280-65bc-11e9-9f88-f40cd04c2aa8.gif)
