### PR TITLE
Add custom node property with index of rows

### DIFF
--- a/.changes/add-rowIndex-field.md
+++ b/.changes/add-rowIndex-field.md
@@ -1,0 +1,5 @@
+---
+"gatsby-source-airtable": patch
+---
+
+Add custom node property with fetched records order

--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@ Get all records from `YOUR_TABLE_NAME` where `Field_1 === YOUR_VALUE`:
 }
 ```
 
+Get all records ordered according selected `tableView`:
+
+```graphql
+{
+  allAirtable(
+    sort: {
+      fields: rowIndex
+    }
+  ) {
+    edges {
+      node {
+        data {
+          Field_1
+        }
+      }
+    }
+  }
+}
+
 ## How it works
 
 When running `gatsby develop` or `gatsby build`, this plugin will fetch all data

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -123,7 +123,8 @@ exports.sourceNodes = async (
     .then((all) => {
       return all.reduce((accumulator, currentValue) => {
         return accumulator.concat(
-          currentValue[0].map((row) => {
+          currentValue[0].map((row, rowIndex) => {
+            row.rowIndex = rowIndex;
             row.queryName = currentValue[1]; // queryName from tableOptions above
             row.defaultValues = currentValue[2]; // mapping from tableOptions above
             row.separateNodeType = currentValue[3]; // separateMapType from tableOptions above
@@ -181,6 +182,7 @@ exports.sourceNodes = async (
         table: row._table.name,
         recordId: row.id,
         queryName: row.queryName,
+        rowIndex: row.rowIndex,
         children: [],
         internal: {
           type: `Airtable${


### PR DESCRIPTION
This allows the use of `rowIndex` node property for sorting GraphQL query results (no matter the node creation order), and so preserving *UI order* of Airtable tables when a view is set in plugin config.


*Testable using `npm install mabhub/gatsby-source-airtable#2.1.1-mkc0`*