### PR TITLE
stop renovate from rebasing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
-  "extends": [
-    "config:base"
-  ],
-  "ignorePaths": []
+  "extends": ["config:base"],
+  "ignorePaths": [],
+  "rebaseWhen": "never",
+  "lockFileMaintenance": { "enabled": true }
 }


### PR DESCRIPTION
It makes it impossible to add a change file if renovate rebases over things constantly. We check mergeability and tests with `bors merge`.