### PR TITLE
[WIP] Add fields param to limit fields returned by Airtable

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,7 +8,7 @@ exports.sourceNodes = async (
   { actions, createNodeId, store, cache },
   { apiKey, tables, concurrency },
 ) => {
-  // tables contain baseId, tableName, tableView, queryName, mapping, tableLinks
+  // tables contain baseId, tableName, tableView, fields, queryName, mapping, tableLinks
   const { createNode, setPluginStatus } = actions;
 
   try {
@@ -54,10 +54,14 @@ exports.sourceNodes = async (
     let table = base(tableOptions.tableName);
 
     let view = tableOptions.tableView || "";
+    
+    let fields = tableOptions.fields || []
 
-    let query = table.select({
-      view: view,
-    });
+    let selectOptions = { view: view };
+    if (fields.length) {
+      select.fields = fields;
+    }
+    let query = table.select(selectOptions);
 
     // confirm that the user is using the clean keys
     // if they are not, warn them and change it for them


### PR DESCRIPTION
This is a very quick/minimal PR to address #272. I haven't tested it with this plugin or Airtable.js but I thought it would serve as a good addition to the conversation over on issue 272. 

But I did curl test the Airtable API and confirmed that yes they are expecting an array of fields and no you cannot send them a string or a blank array. (e.g. this request worked as expected: `https://api.airtable.com/v0/{base-id-redacted}/Campaigns?maxRecords=1&view=public_posts_for_internet&fields%5B%5D=Name&fields%5B%5D=Region`)