### PR TITLE
Add logging message in catch

### DIFF
--- a/.changes/add-logging.md
+++ b/.changes/add-logging.md
@@ -1,0 +1,6 @@
+---
+"gatsby-source-airtable": patch
+---
+
+Add logging statement
+

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -137,6 +137,7 @@ exports.sourceNodes = async (
       }, []);
     })
     .catch((e) => {
+      console.warn("Error fetching tables: " + e);
       throw e;
       return;
     });


### PR DESCRIPTION
This will help people debug API key and baseId errors where the airtable api returns an error status code.

warn Error fetching tables: Could not find what you are looking for(NOT_FOUND)[Http code 404]