### PR TITLE
fix: pulling in mp3 files does not convert back to mpga

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -305,6 +305,10 @@ const localFileCheck = async (
       // the cleanKey here
       data[key].forEach((attachment) => {
         const ext = mime.getExtension(attachment.type); // unknown type returns null
+        if (ext === 'mpga') {
+          // mpga files are not digested by filesystem, as it creates an ext mismatch between airtable and the local file
+          ext = "mp3"
+        }
         let attachmentNode = createRemoteFileNode({
           url: attachment.url,
           store,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -304,7 +304,7 @@ const localFileCheck = async (
       // `data` is direct from Airtable so we don't use
       // the cleanKey here
       data[key].forEach((attachment) => {
-        const ext = mime.getExtension(attachment.type); // unknown type returns null
+        let ext = mime.getExtension(attachment.type); // unknown type returns null
         if (ext === 'mpga') {
           // mpga files are not digested by filesystem, as it creates an ext mismatch between airtable and the local file
           ext = "mp3"


### PR DESCRIPTION
This is an attempt to rectify https://github.com/jbolda/gatsby-source-airtable/issues/371 This fix ensures that the file extension does not get changed when we pull from airtable. Tested locally and indeed, the files that are downloaded do not change over when they finally land in the static folder. I'm not exactly sure if this is the most sustainable way to do this, but opened mainly so I can pull this branch in for my specific purposes.