### PR TITLE
Fix: Pull fileNode file name from airtable metadata

### DIFF
--- a/.changes/fix-airtable-filenames.md
+++ b/.changes/fix-airtable-filenames.md
@@ -1,0 +1,9 @@
+---
+"gatsby-source-airtable": minor
+---
+
+This makes the fileNode pull `name` from the airtable metadata instead of the
+remote file, because when an airtable user changes the file name, airtable does
+not rename the original url. This change makes file name changes in airtable
+usable in the fileNode instead of needing to download, rename, and re-upload the
+file.

--- a/.changes/fix-airtable-filenames.md
+++ b/.changes/fix-airtable-filenames.md
@@ -1,5 +1,5 @@
 ---
-"gatsby-source-airtable": minor
+"gatsby-source-airtable": patch
 ---
 
 This makes the fileNode pull `name` from the airtable metadata instead of the

--- a/.changes/fix-airtable-filenames.md
+++ b/.changes/fix-airtable-filenames.md
@@ -1,5 +1,5 @@
 ---
-"gatsby-source-airtable": patch
+"gatsby-source-airtable": minor
 ---
 
 This makes the fileNode pull `name` from the airtable metadata instead of the

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -305,12 +305,17 @@ const localFileCheck = async (
       // `data` is direct from Airtable so we don't use
       // the cleanKey here
       data[key].forEach((attachment) => {
-        const ext = mime.getExtension(attachment.type); // unknown type returns null
         // get the filename from the airtable metadata instead of the remote file
-        const airtableFileName = path.parse(attachment.filename).name;
+        const airtableFile = path.parse(attachment.filename);
+        // console.log(airtableFile);
+        let ext = airtableFile.ext;
+        if (!ext) {
+          const deriveExt = mime.getExtension(attachment.type); // unknown type returns null
+          ext = !!deriveExt ? `.${deriveExt}` : undefined;
+        }
         let attachmentNode = createRemoteFileNode({
           url: attachment.url,
-          name: airtableFileName,
+          name: airtableFile.name.replace(/[/\\?%*:|"<>]/g, ""),
           store,
           cache,
           createNode,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,6 +3,7 @@ const crypto = require("crypto");
 const { createRemoteFileNode } = require("gatsby-source-filesystem");
 const { map } = require("bluebird");
 const mime = require("mime/lite");
+const path = require("path");
 
 exports.sourceNodes = async (
   { actions, createNodeId, store, cache },
@@ -305,8 +306,11 @@ const localFileCheck = async (
       // the cleanKey here
       data[key].forEach((attachment) => {
         const ext = mime.getExtension(attachment.type); // unknown type returns null
+        // get the filename from the airtable metadata instead of the remote file
+        const airtableFileName = path.parse(attachment.filename).name;
         let attachmentNode = createRemoteFileNode({
           url: attachment.url,
+          name: airtableFileName,
           store,
           cache,
           createNode,


### PR DESCRIPTION
This makes the fileNode pull `name` from the airtable
metadata instead of the remote file, because when an airtable
user changes the file name, airtable does not rename the original
file. This change makes file name changes in airtable usable in
the fileNode instead of needing to download, rename, and
re-upload the file.